### PR TITLE
feat: enable to define entry file regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,10 @@
     },
     "packages/plugin": {
       "name": "vite-plugin-vue-hoist-ce-styles",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.3.4",
-        "@types/acorn": "^6.0.0",
-        "esbuild": "^0.14.50",
         "rollup": "^2.77.2",
         "tslib": "^2.4.0",
         "typescript": "^4.7.4",
@@ -68,30 +66,10 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
-    "packages/plugin/node_modules/@types/acorn": {
-      "version": "6.0.0",
-      "deprecated": "This is a stub types definition. acorn provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "*"
-      }
-    },
     "packages/plugin/node_modules/@types/estree": {
       "version": "0.0.39",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/plugin/node_modules/acorn": {
-      "version": "8.8.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "packages/plugin/node_modules/esbuild": {
       "version": "0.14.50",
@@ -341,8 +319,6 @@
       "version": "file:packages/plugin",
       "requires": {
         "@rollup/plugin-typescript": "^8.3.4",
-        "@types/acorn": "^6.0.0",
-        "esbuild": "^0.14.50",
         "rollup": "^2.77.2",
         "tslib": "^2.4.0",
         "typescript": "^4.7.4",
@@ -366,19 +342,8 @@
             "picomatch": "^2.2.2"
           }
         },
-        "@types/acorn": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "acorn": "*"
-          }
-        },
         "@types/estree": {
           "version": "0.0.39",
-          "dev": true
-        },
-        "acorn": {
-          "version": "8.8.0",
           "dev": true
         },
         "esbuild": {

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -4,7 +4,7 @@
 ### Caveats
 
 - CSS imports outside of SFCs won't work. E.g. the default `import 'styles.css'` in main.ts will work in dev but break the build.
-- Your bundle must be named `index.%%ANYTHING%%.js` as the plugin is testing against `/index.*.js` to replace styles in the final bundle
+- Plugin check bundle name `index.%%ANYTHING%%.js` by default to replace styles in the final bundle
 - Plugin has no unit tests right now, and is largely untested, use with caution
 
 ### Installation
@@ -28,5 +28,12 @@ import { hoistCeStyles } from 'vite-plugin-vue-hoist-ce-styles';
 plugins: [vue({ customElement: true }), hoistCeStyles({hostComponent: 'App.vue'})],
 ```
 
+You can define a parameter indexRe to define your entry file name as a RegExp
+
+```typescript
+import { hoistCeStyles } from 'vite-plugin-vue-hoist-ce-styles';
+
+plugins: [vue({ customElement: true }), hoistCeStyles({ hostComponent: 'App.vue', indexRe: /entry-file.js/ })],
+```
 
 

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -3,7 +3,7 @@ import type { OutputChunk } from 'rollup';
 
 const directRe = /\&direct/;
 const styleRe = /(\.css|\&type\=style)/;
-const indexRe = /index.*.js/;
+const defaultIndexRe = /index.*.js/;
 
 const PLACEHOLDER_BEGIN = 'ANCHOR:BEGIN';
 const PLACEHOLDER_END = 'ANCHOR:END';
@@ -44,12 +44,12 @@ function toStyleCode(styleCache: StyleCache) {
 }
 
 function toRefCode(referenceMap: Map<string, string>) {
-  return [...referenceMap].reduce((current, [hash, linkedRef]) => 
+  return [...referenceMap].reduce((current, [hash, linkedRef]) =>
     `${current}\nconst __${hash}__ = ${linkedRef}`
-  , '');
+    , '');
 }
 
-export function hoistCeStyles({ hostComponent }: { hostComponent: string }): Plugin {
+export function hoistCeStyles({ hostComponent, indexRe = defaultIndexRe }: { hostComponent: string, indexRe: RegExp }): Plugin {
   const styleCache: StyleCache = [];
   const hostComponentRe = new RegExp(hostComponent);
   let refMap = new Map<string, string>();
@@ -144,7 +144,7 @@ export function hoistCeStyles({ hostComponent }: { hostComponent: string }): Plu
           chunk.code = chunk.code.replace(assetRetrievalRE, '');
 
           const componentStyles = chunk.code.matchAll(placeHolderRe);
-          for (const [anchor, id ]of componentStyles) {
+          for (const [anchor, id] of componentStyles) {
             if (hostComponentRe.test(id)) {
               chunk.code = chunk.code.replace(anchor, styleCode);
             } else {


### PR DESCRIPTION
Hello,

Thank you for your plugin.

Here is a little PR to give the possibility to define a RegExp for entry file for the plugin. Default to index.*.js like before.