### PR TITLE
fix(typescript): use semicolon instead of comma

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -49,7 +49,7 @@ function toRefCode(referenceMap: Map<string, string>) {
     , '');
 }
 
-export function hoistCeStyles({ hostComponent, indexRe = defaultIndexRe }: { hostComponent: string, indexRe: RegExp }): Plugin {
+export function hoistCeStyles({ hostComponent, indexRe = defaultIndexRe }: { hostComponent: string; indexRe: RegExp }): Plugin {
   const styleCache: StyleCache = [];
   const hostComponentRe = new RegExp(hostComponent);
   let refMap = new Map<string, string>();


### PR DESCRIPTION
I used a comma instead of a semicolon for the plugin TypeScript definition. Sorry for that.

I checked the output file and the d.ts file is good now